### PR TITLE
use tag field to control the version of julia we use.

### DIFF
--- a/myplugins.jl
+++ b/myplugins.jl
@@ -3,20 +3,21 @@ using PkgTemplates: FilePlugin, Template
 import PkgTemplates: source, destination, view
 
 struct Dockerfile <: FilePlugin
+    tag::String
     file::String
     destination::String
-    function Dockerfile(;with_jupyter=false)
+    function Dockerfile(;tag=string(VERSION), with_jupyter=false)
         if with_jupyter
-            new(joinpath("templates", "with_jupyter", "Dockerfile"), "Dockerfile")
+            new(tag, joinpath("templates", "with_jupyter", "Dockerfile"), "Dockerfile")
         else
-            new(joinpath("templates", "Dockerfile"), "Dockerfile")
+            new(tag, joinpath("templates", "Dockerfile"), "Dockerfile")
         end
     end
 end
 
 source(p::Dockerfile) = p.file
 destination(p::Dockerfile) = p.destination
-view(::Dockerfile, ::Template, pkg::AbstractString) = Dict("PKG" => pkg)
+view(f::Dockerfile, ::Template, pkg::AbstractString) = Dict("PKG" => pkg, "tag" => f.tag)
 
 # ---
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6.4
+FROM julia:{{tag}}
 
 # create user with a home directory
 ARG NB_USER=jovyan

--- a/templates/with_jupyter/Dockerfile
+++ b/templates/with_jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6.4
+FROM julia:{{tag}}
 
 # create user with a home directory
 ARG NB_USER=jovyan


### PR DESCRIPTION
If one specifies `Dockerfile(; tag="1.7.0")`, it will create Dockerfile its base image is `julia:1.7.0`. 