### PR TITLE
add shell option

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -8,8 +8,8 @@ build:
 	-rm -f Manifest.toml docs/Manifest.toml
 	docker build -t ${DOCKER_IMAGE} . --build-arg NB_UID=`id -u`
 	docker-compose build
-	docker-compose run --rm julia julia --project=@. -e 'using Pkg; Pkg.instantiate()'
-	docker-compose run --rm julia julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+	docker-compose run --rm shell julia --project=@. -e 'using Pkg; Pkg.instantiate()'
+	docker-compose run --rm shell julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 
 # Excecute in docker container
 web: docs
@@ -19,7 +19,7 @@ web: docs
 		'
 
 test: build
-	docker-compose run --rm julia julia -e 'using Pkg; Pkg.activate("."); Pkg.test()'
+	docker-compose run --rm shell julia -e 'using Pkg; Pkg.activate("."); Pkg.test()'
 
 clean:
 	docker-compose down

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -7,6 +7,15 @@ services:
       - ./:/workspace/{{{PKG}}}.jl
     working_dir: /workspace/{{{PKG}}}.jl
     command: julia --project=/workspace/{{{PKG}}}.jl
+
+  shell:
+    image: {{DOCKER_IMAGE}}
+    container_name: {{DOCKER_IMAGE}}-julia
+    volumes:
+      - ./:/workspace/{{{PKG}}}.jl
+    working_dir: /workspace/{{{PKG}}}.jl
+    command: /bin/bash
+
   web:
     image: {{DOCKER_IMAGE}}
     container_name: {{DOCKER_IMAGE}}-packagedocs

--- a/templates/with_jupyter/docker-compose.yml
+++ b/templates/with_jupyter/docker-compose.yml
@@ -25,6 +25,13 @@ services:
       - ./:/workspace/{{{PKG}}}.jl
     working_dir: /workspace/{{{PKG}}}.jl
     command: julia --project=/workspace/{{{PKG}}}.jl
+  shell:
+    image: {{DOCKER_IMAGE}}
+    container_name: {{DOCKER_IMAGE}}-shell
+    volumes:
+      - ./:/workspace/{{{PKG}}}.jl
+    working_dir: /workspace/{{{PKG}}}.jl
+    command: /bin/bash
   web:
     image: {{DOCKER_IMAGE}}
     container_name: {{DOCKER_IMAGE}}-packagedocs


### PR DESCRIPTION
writing `docker-compose run --rm julia julia ...` is slightly redundant.
Instead of `julia` as a service, we create`shell` service which works as a service named `julia`