### PR TITLE
fix

### DIFF
--- a/templates/dot_vscode/extensions.json
+++ b/templates/dot_vscode/extensions.json
@@ -3,6 +3,6 @@
         "ms-vscode-remote.vscode-remote-extensionpack",
         "julialang.language-julia",
         "bungcip.better-toml",
-	"congyiwu.vscode-jupytext",
+        "donjayamanne.vscode-jupytext",
     ]
 }


### PR DESCRIPTION
It seems donjayamanne.vscode-jupytext is the original extension. Therefore we set this ID.